### PR TITLE
Support Flask app_prefix to allow serving app from a subpath

### DIFF
--- a/srv/python/mviewerstudio_backend/app_factory.py
+++ b/srv/python/mviewerstudio_backend/app_factory.py
@@ -20,7 +20,11 @@ def load_error_handlers(app: Flask) -> None:
 
 
 def load_blueprint(app: Flask) -> None:
-    app.register_blueprint(basic_store)
+    app_prefix = app.config.get("MVIEWERSTUDIO_URL_PATH_PREFIX", "")
+    if app_prefix:
+        # Handle possible missing or excess / chars: needs to start with one but not end with one
+        app_prefix = "/" + app_prefix.strip("/")
+    app.register_blueprint(basic_store, url_prefix=app_prefix)
 
 
 def init_publish_directory(app: Flask) -> None:

--- a/srv/python/mviewerstudio_backend/settings.py
+++ b/srv/python/mviewerstudio_backend/settings.py
@@ -19,3 +19,5 @@ class Config:
         "MVIEWERSTUDIO_PUBLISH_PATH", "/home/user/git/mviewer/apps/public"
     )
     DEFAULT_ORG = os.getenv("DEFAULT_ORG", "public")
+    URL_PATH_PREFIX = os.getenv("MVIEWERSTUDIO_URL_PATH_PREFIX", "")
+


### PR DESCRIPTION
Uses an environment variable MVIEWERSTUDIO_URL_PATH_PREFIX 

e.g. MVIEWER_STUDIO_URL_PATH_PREFIX=mviewerstudio will server api/user at {host}/mviewerstudio/api/user