### PR TITLE
#291 remove max features 100

### DIFF
--- a/lib/ogc.js
+++ b/lib/ogc.js
@@ -607,7 +607,6 @@ var ogc = (function () {
         VERSION: "1.0.0",
         REQUEST: "GETFEATURE",
         OUTPUTFORMAT: "application/json",
-        MAXFEATURES: 100,
         ...props,
       };
 


### PR DESCRIPTION
Devrait corriger l'issue #291 en supprimant la limite de 100 features par appel getFeature au détriment de la performance (expérience utilisateur potentiellement ralentie -> A la demande des utilisateurs).