### PR TITLE
fix layer id from active layer

### DIFF
--- a/js/mviewerstudio.js
+++ b/js/mviewerstudio.js
@@ -412,7 +412,7 @@ var editLayer = function (item, themeid, layerid) {
   mv.setCurrentLayerId(layerid);
   var element = $(item).parent().parent();
   var layerid = element.attr("data-layerid");
-
+  element.addClass("active");
   if (layerid != "undefined") {
     $("#mod-layerOptions").modal("show");
     mv.showLayerOptions(element, themeid, layerid);

--- a/lib/mv.js
+++ b/lib/mv.js
@@ -49,6 +49,15 @@ var mv = (function () {
         layerid = el.attr("data-layerid");
       }
       var themeid = mv.getCurrentThemeId();
+      if (!themeid) {
+        // search theme id from config object
+        themeid = Object.keys(config.themes)
+          .filter((f) => {
+            const them = config.themes[f];
+            return them.layers.filter((l) => l.id === layerid)?.length;
+          })
+          .filter((x) => x)[0];
+      }
       return config.themes[themeid].layers.find((l) => l.id === layerid);
     },
 


### PR DESCRIPTION
Correctif suite à la #324 

- Récupération des ID de layer à partir de la méthode mv.getCurrentLayerId (le mode actif des layers n'étant plus utilisé comme précédemment)