### PR TITLE
#380 lib/ogc - utilisation de fetch

### DIFF
--- a/config-python-sample.json
+++ b/config-python-sample.json
@@ -1,15 +1,15 @@
 {
     "app_conf": {
         "studio_title": "Mviewer Studio",
-        "mviewer_version":  "3.13",
-        "mviewerstudio_version":  "4.2",
+        "mviewer_version":  "4",
+        "mviewerstudio_version":  "4.3-snapshot",
         "api": "api/app",
         "store_style_service": "api/style",
         "mviewer_instance": "/mviewer/",
         "publish_url": "/mviewer/?config=apps/public/{{config}}.xml",
         "conf_path_from_mviewer": "apps/store/",
         "mviewer_short_url": {
-            "used": true,
+            "used": false,
             "apps_folder": "store",
             "public_folder": "public"
         },
@@ -178,7 +178,7 @@
                     "title": "Catalogue de la Région Grand Est",
                     "url": "https://datagrandest.fr/geonetwork/srv/fre/csw",
                     "baseref": "https://datagrandest.fr/geonetwork/srv/eng/catalog.search?node=srv#/metadata/"
-                }
+                }       
             ],
             "wms": [{
                 "title": "Serveur WMS de la Région",

--- a/lib/mv.js
+++ b/lib/mv.js
@@ -71,7 +71,7 @@ var mv = (function () {
   function uuid() {
     var dt = new Date().getTime();
     var uuid = "xxxxxxxxxxxx".replace(/[xy]/g, function (c) {
-      var r = (dt + Math.random() * 16) % 16 | 0;
+      var r = ((dt + Math.random() * 16) % 16) | 0;
       dt = Math.floor(dt / 16);
       return (c == "x" ? r : (r & 0x3) | 0x8).toString(16);
     });

--- a/lib/ogc.js
+++ b/lib/ogc.js
@@ -241,28 +241,38 @@ var ogc = (function () {
     mv.showCSWResults(results);
   };
 
+  var _parseXml = function (text) {
+    var parser = new DOMParser();
+    return parser.parseFromString(text, "text/xml");
+  };
+
   var _cswAjax = function (url, body, metadataUrl, typeNames) {
-    $.ajax({
-      type: "POST",
-      url: mv.ajaxURL(url),
-      crossDomain: true,
-      data: body,
-      dataType: "xml",
-      contentType: "application/xml",
-      success: function (data) {
-        _cswParse(data, url, metadataUrl, typeNames);
+    fetch(mv.ajaxURL(url), {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/xml",
       },
-      error: function (xhr, ajaxOptions, thrownError) {
+      body: body,
+    })
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(
+            "CSW request failed: " + response.status + " " + response.statusText
+          );
+        }
+        return response.text();
+      })
+      .then((data) => {
+        _cswParse(_parseXml(data), url, metadataUrl, typeNames);
+      })
+      .catch((error) => {
         console.error("CSW request failed", {
           url: url,
           body: body,
-          xhr: xhr,
-          ajaxOptions: ajaxOptions,
-          thrownError: thrownError,
+          error: error,
         });
         alert("Echec de la requête CSW :\n" + url);
-      },
-    });
+      });
   };
 
   var _wmsCapabilitiesParse = function (data, layerid) {
@@ -405,25 +415,28 @@ var ogc = (function () {
         ? getCapabilitiesUrl + "?" + getCapabilitiesParams
         : getCapabilitiesUrl + "&" + getCapabilitiesParams;
 
-    $.ajax({
-      type: "GET",
-      url: mv.ajaxURL(getCapabilitiesUrl),
-      crossDomain: true,
-      dataType: "xml",
-      contentType: "application/xml",
-      success: function (data) {
-        _wmsParse(data, keyword);
-      },
-      error: function (xhr, ajaxOptions, thrownError) {
+    fetch(mv.ajaxURL(getCapabilitiesUrl))
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(
+            "WMS GetCapabilities request failed: " +
+              response.status +
+              " " +
+              response.statusText
+          );
+        }
+        return response.text();
+      })
+      .then((data) => {
+        _wmsParse(_parseXml(data), keyword);
+      })
+      .catch((error) => {
         console.error("WMS GetCapabilities request failed", {
           url: getCapabilitiesUrl,
-          xhr: xhr,
-          ajaxOptions: ajaxOptions,
-          thrownError: thrownError,
+          error: error,
         });
         alert("Echec de la requête WMS GetCapabilities :\n" + getCapabilitiesUrl);
-      },
-    });
+      });
   };
 
   var _DescribeFeatureTypeParse = function (data, typeName, layerid, url) {
@@ -465,12 +478,7 @@ var ogc = (function () {
         ? descFeatTypeUrl + "?" + descFeatTypeParams
         : descFeatTypeUrl + "&" + descFeatTypeParams;
 
-    return fetch(mv.ajaxURL(descFeatTypeUrl), {
-      mode: "cors",
-      headers: {
-        "Content-Type": "application/xml",
-      },
-    })
+    return fetch(descFeatTypeUrl)
       .then((response) => response.text())
       .then((data) => {
         return _DescribeFeatureTypeParse(data, typeName, layerid, url);
@@ -488,25 +496,28 @@ var ogc = (function () {
         ? getCapabilitiesUrl + "?" + getCapabilitiesParams
         : getCapabilitiesUrl + "&" + getCapabilitiesParams;
 
-    $.ajax({
-      type: "GET",
-      url: mv.ajaxURL(getCapabilitiesUrl),
-      crossDomain: true,
-      dataType: "xml",
-      contentType: "application/xml",
-      success: function (data) {
-        _wmsCapabilitiesParse(data, layerid);
-      },
-      error: function (xhr, ajaxOptions, thrownError) {
+    fetch(getCapabilitiesUrl)
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(
+            "WMS GetCapabilities request failed: " +
+              response.status +
+              " " +
+              response.statusText
+          );
+        }
+        return response.clone().text();
+      })
+      .then((data) => {
+        _wmsCapabilitiesParse(_parseXml(data), layerid);
+      })
+      .catch((error) => {
         console.error("WMS GetCapabilities request failed", {
           url: getCapabilitiesUrl,
-          xhr: xhr,
-          ajaxOptions: ajaxOptions,
-          thrownError: thrownError,
+          error: error,
         });
         alert("Echec de la requête WMS GetCapabilities :\n" + getCapabilitiesUrl);
-      },
-    });
+      });
   };
 
   var _describeLayerParse = function (xml, layerid) {
@@ -524,12 +535,7 @@ var ogc = (function () {
         ? descLayerUrl + "?" + descLayerParams
         : descLayerUrl + "&" + descLayerParams;
 
-    return fetch(mv.ajaxURL(descLayerUrl), {
-      mode: "cors",
-      headers: {
-        "Content-Type": "application/xml",
-      },
-    })
+    return fetch(mv.ajaxURL(descLayerUrl))
       .then((response) => response.text())
       .then((data) => {
         return {
@@ -613,25 +619,28 @@ var ogc = (function () {
       let newUrl = ogc.urlToObject(url, queryParams);
       let stringUrl = newUrl.toString();
 
-      $.ajax({
-        type: "GET",
-        url: mv.ajaxURL(stringUrl),
-        crossDomain: true,
-        dataType: "json",
-        contentType: "application/json",
-        success: function (data) {
+      fetch(stringUrl)
+        .then((response) => {
+          if (!response.ok) {
+            throw new Error(
+              "WFS GetFeature request failed: " +
+                response.status +
+                " " +
+                response.statusText
+            );
+          }
+          return response.json();
+        })
+        .then((data) => {
           onSuccess(data);
-        },
-        error: function (xhr, ajaxOptions, thrownError) {
+        })
+        .catch((error) => {
           console.error("WFS GetFeature request failed", {
             url: stringUrl,
-            xhr: xhr,
-            ajaxOptions: ajaxOptions,
-            thrownError: thrownError,
+            error: error,
           });
           alert("Echec de la requête WFS GetFeature :\n" + stringUrl);
-        },
-      });
+        });
     },
   };
 })();


### PR DESCRIPTION
> ref #380 

**Merci à l'ARS Île-de-France / GIP SESAN pour le financement de cette contribution.** 

<img width="281" height="157" alt="image" src="https://github.com/user-attachments/assets/befb1d2a-482d-41d5-adc9-231a36fa7caa" />

- https://www.iledefrance.ars.sante.fr/
- https://www.sesan.fr/

### Description

Corrige des problèmes d'appels : 

- utilsation de fetch à la place de l'appel JQuery / ajax
- supprime les en-tête inutiles provoquant des erreurs CORS
- permet d'appeler les flux BRGM et géorisque


### Tests

Il faut utiliser les flux WMS suivants dans `static/apps/config.json `: 

> entrées à rajouter dans `data_providers.wms` :

```
{
      "title": "Catalogue GéoRisque",
      "url": "https://georisques.gouv.fr/services"
  },{
      "title": "Catalogue BRGM - Géologie",
      "url": "https://geoservices.brgm.fr/risques?service=WMS&version=1.3.0&request=GetCapabilities"
  }
```

A tester sur votre propre instance.

Sinon, testable ici : 

https://gis.jdev.fr/mviewerstudio/index.html#


<img width="830" height="715" alt="image" src="https://github.com/user-attachments/assets/517b9231-8e95-4a78-bf04-c79e81f5c3ec" />
