### PR TITLE
fix:#370 - preview layer settings as  xml

### DIFF
--- a/src/static/lib/mv.js
+++ b/src/static/lib/mv.js
@@ -1051,11 +1051,20 @@ var mv = (function () {
     form2xml: function () {
       var el = $(".layers-list-item.active");
       var layerid = el.attr("data-layerid");
-      var themeid = $("#theme-edit").attr("data-themeid");
+      var themeid = $("#theme-edit").attr("data-themeid") || mv.getCurrentThemeId();
       function getLayerbyId(l) {
         return l.id === layerid;
       }
-      var layer = config.themes[themeid].layers.find(mv.getLayerById);
+      var layer = null;
+      if (themeid && config.themes[themeid]) {
+        layer = config.themes[themeid].layers.find(getLayerbyId);
+      }
+      if (!layer) {
+        layer = mv.getLayerById(layerid);
+      }
+      if (!layer) {
+        return;
+      }
       var xml = mv.writeLayerNode(layer);
       $("#mod-codeview pre").text(xml);
     },


### PR DESCRIPTION
Permet de corriger le fonctionnalité qui permet de voir le paramètre de couche en XML

<img width="1906" height="937" alt="image" src="https://github.com/user-attachments/assets/1b00f444-4eb8-4119-b40e-c45997340f1e" />
