### PR TITLE
Change default UID and GID in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.11-slim
 
-ARG UID=1000
-ARG GID=1000
+ARG UID=999
+ARG GID=999
 
 #install git & studio dependencies
 RUN apt-get update && \


### PR DESCRIPTION
Before the commit 33eec59#diff-f34da55ca08f1a30591d8b0b3e885bcc678537b2a9a4aadea4f190806b374ddc. The user for mviewerstudio was 999.

This got switched to 1000.

This pose issues for existing installations that had uid 999 and for the files shared with other applications such as SFTP servers.

An SFTP server could be used for adapting the mviewer config files.